### PR TITLE
Fix: 스트림 키 해당 방송정보와 연동하여 본인 스트림키로 스트리밍 연결 하던 오류 해결

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -148,12 +148,11 @@ export const updateIntro = async (intro: string) => {
   return res;
 };
 
-export const getStreamKey = async (): Promise<string> => {
+export const getStreamKey = async (streamerNickname: string | undefined): Promise<string> => {
   const accessToken = localStorage.getItem('accessToken');
   const refreshToken = localStorage.getItem('refreshToken');
   const authAxios = getAuthAxios(accessToken!, refreshToken!);
-
-  const res = (await authAxios.get('/api/api/users/stream-key')).data;
+  const res = (await authAxios.get(`/api/api/users/stream-key/${streamerNickname}`)).data;
   return res;
 };
 

--- a/src/pages/StreamingLive.tsx
+++ b/src/pages/StreamingLive.tsx
@@ -1,6 +1,5 @@
 import { useParams } from 'react-router-dom';
 import StreamVideo from '../components/StreamVideo';
-import { useStreamServer } from '../utils/streaming/useStreamServer';
 import { useStreamDetail } from '../utils/streaming/useStreamDetail';
 import { useEffect, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -8,6 +7,7 @@ import { currentUserInfo, notifyList } from '../store';
 import { deleteStreaming, getSubscribeList, addSubscribe, deleteSubscribe } from '../api';
 import { useNavigate } from 'react-router-dom';
 import { useMutation } from '@tanstack/react-query';
+import { createStreamServer } from '../utils/streaming/createStreamServer';
 import Modal from '../components/Modal';
 import Chat from '../components/Chat';
 
@@ -15,7 +15,6 @@ const testUrl = 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8';
 
 export default function StreamingLive() {
   const navigate = useNavigate();
-  const streamServer = useStreamServer();
   const { id } = useParams();
   const { data, isLoading } = useStreamDetail(id);
   const [streamDetail, setStreamDetail] = useState(data);
@@ -23,6 +22,7 @@ export default function StreamingLive() {
   const userInfo = useRecoilValue(currentUserInfo);
   const isAuthor = streamDetail?.streamerNickname === userInfo.nickname;
   const [streamList, setStreamList] = useRecoilState(notifyList);
+  const streamServerUrl = createStreamServer(streamDetail?.streamerStreamKey);
 
   const updateNotifyList = (streamerNickname: string | undefined) => {
     const newNotifyList = streamList.filter((nickname: string) => nickname !== streamerNickname);
@@ -84,7 +84,7 @@ export default function StreamingLive() {
     <div className='flex justify-center w-full h-screen lg:items-start flex-grow-1 sm:flex-col sm:items-center lg:flex-row bg-base-200'>
       <div className='mt-2 flex flex-col lg:w-2/3 lg:h-[90%] sm:w-full border-2 rounded-lg border-slate-500'>
         <div className='flex items-center justify-center h-5/6'>
-          <StreamVideo src={streamServer} streamId={id} isAuthor={isAuthor} />
+          <StreamVideo src={streamServerUrl} streamId={id} isAuthor={isAuthor} />
         </div>
         <div className='flex flex-col gap-2 p-2 lg:h-1/6'>
           <p className='text-2xl sm:text-lg'>{streamDetail?.title}</p>

--- a/src/pages/StreamingSetting.tsx
+++ b/src/pages/StreamingSetting.tsx
@@ -6,10 +6,13 @@ import { STREAM_CATEGORY_LIST, STREAM_URL } from '../constants/constant';
 import { LiveSet } from '../types/interface';
 import { FaEye } from 'react-icons/fa';
 import { FaEyeSlash } from 'react-icons/fa';
+import { useRecoilValue } from 'recoil';
+import { currentUserInfo } from '../store';
 
 export default function StreamingSetting() {
   const navigate = useNavigate();
-  const { data } = useStreamKey();
+  const useInfo = useRecoilValue(currentUserInfo);
+  const { data } = useStreamKey(useInfo.nickname);
   const [streamKey, setStreamKey] = useState(data || '');
   const [isView, setIsView] = useState(false);
 

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -51,6 +51,7 @@ export interface StreamDetail {
   title: string;
   category: string;
   streamerNickname: string;
+  streamerStreamKey: string;
   profilePhotoUrl: string;
   startAt: string;
   viewerCount: null;

--- a/src/utils/streaming/createStreamServer.ts
+++ b/src/utils/streaming/createStreamServer.ts
@@ -1,7 +1,4 @@
-import { useStreamKey } from './useStreamKey';
-
-export const useStreamServer = (): string => {
-  const { data: streamKey } = useStreamKey();
+export const createStreamServer = (streamKey: string | undefined): string => {
   // return `https://15.164.226.60:8080/hls/${streamKey}_src.m3u8`;
   return `https://ec2-15-164-226-60.ap-northeast-2.compute.amazonaws.com/hls/${streamKey}_src.m3u8`;
 };

--- a/src/utils/streaming/useStreamKey.ts
+++ b/src/utils/streaming/useStreamKey.ts
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { getStreamKey } from '../../api';
 
-export const useStreamKey = () => {
+export const useStreamKey = (streamerNickname: string | undefined) => {
+  console.log(streamerNickname);
   const { data, isLoading, isError } = useQuery<string>({
     queryKey: ['stream-key'],
-    queryFn: getStreamKey,
+    queryFn: () => getStreamKey(streamerNickname),
   });
-
   return { data, isLoading, isError };
 };


### PR DESCRIPTION
## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 문서 추가
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ✨ 과제 내용

+ 기존 streamKey 불러오는 함수는 access토큰을 기반으로 가져왔기 때문에 라이브중인 방송에 들어가도 방송을 킨 스트리머의 streamKey가 아닌 본인의 streamKey로 연결이 되기떄문에 방송이 보이지 않던 오류가 있었음
+ 그래서 streamKey를 nickname 형식으로 구분할수있게 수정하여 라이브방 입장 시 해당 닉네임으로 식별된 streamKey로 방송송출되도록 수정하였음
<!-- 과제에 대한 설명을 적어주세요 -->

